### PR TITLE
add - Adicionando $customAttributes para tradução dos names dos inputs.

### DIFF
--- a/src/CpfCnpjServiceProvider.php
+++ b/src/CpfCnpjServiceProvider.php
@@ -14,9 +14,9 @@ class CpfCnpjServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->app->validator->resolver(function($translator, $data, $rules, $messages)
+		$this->app->validator->resolver(function($translator, $data, $rules, $messages, $customAttributes)
 		{
-		    return new CpfCnpjValidation($translator, $data, $rules, $messages);
+		    return new CpfCnpjValidation($translator, $data, $rules, $messages, $customAttributes);
 		});
 	}
 


### PR DESCRIPTION
O parâmetro $customAttributes faz com que a mensagem exibida na validação seja um nome diferente do name do input.

https://laravel.com/docs/5.5/validation#custom-error-messages